### PR TITLE
Updated doc with the right LinuxKit run subcommand

### DIFF
--- a/docs/platform-azure.md
+++ b/docs/platform-azure.md
@@ -34,7 +34,7 @@ This will output a `azure.vhd` image.
 To deploy the `azure.vhd` image on Azure, invoke the following command:
 
 ```
-linuxkit run azure --resource-group <resource-group-name> --storage-account <storage-account-name> --location westeurope <path-to-your-azure.vhd>
+linuxkit run azure -resourceGroupName <resource-group-name> -accountName <storage-account-name> -location westeurope <path-to-your-azure.vhd>
 ```
 
 Sample output of the command:

--- a/reports/sig-security/2017-08-02.md
+++ b/reports/sig-security/2017-08-02.md
@@ -1,0 +1,18 @@
+# 2017-08-02
+Time: **9am PDT** (12pm EDT, 5pm BST) [see the time in your timezone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Linuxkit+Security+SIG&iso=20170802T09&p1=224)
+
+Meeting location: https://docker.zoom.us/j/779801882
+
+Announcement: Moby project forum post - coming soon
+
+Previous meeting notes: [2017-07-19](2017-07-19.md)
+
+## Agenda
+- Introductions & Administrivia (5 min)
+- Alpine Linux - security deep dive - @ncopa (45 min)
+- Project updates (10 min)
+- Next meeting: 2017-08-16
+  - deep dive TBD
+  - please feel free to propose additional deep dives and discussion topics!
+
+## Meeting Notes


### PR DESCRIPTION
The document showed the incorrect sub-command options for LinuxKit run azure  which needs to be updated and hence fixed it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/linuxkit/linuxkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Modified the incorrect Linuxkit run command for Azure.



**- How I did it**

linuxkit run azure -resourceGroupName <resource-group-name> -accountName <storage-account-name> -location westeurope <path-to-your-azure.vhd>

**- How to verify it**

$git clone https://github.com/linuxkit/linuxkit
$cd linuxkit
$make
$cp -rf bin/moby /usr/local/bin/
$cp -rf bin/linuxkit /usr/local/bin/
$cd linuxkit/examples/azure
$moby build -o vhd azure.yml
$ linuxkit run azure --resourceGroupName mylinuxkitresource --accountName mylinuxkitstorage -location eastasia azure.vhd

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![63bb616a33fc209cd3a48795c981f46d--mini-husky-alaskan-klee-kai](https://user-images.githubusercontent.com/313480/28771515-c44ff46a-7600-11e7-948f-8f7b8883970a.jpg)
